### PR TITLE
Workshop Playbook

### DIFF
--- a/foo/world.txt.bak
+++ b/foo/world.txt.bak
@@ -1,0 +1,1 @@
+Hello World

--- a/hello.yml
+++ b/hello.yml
@@ -1,6 +1,6 @@
 ---
 - name: Hello World
-  hosts:
+  hosts: localhost
   connection: local
   tasks:
 
@@ -10,14 +10,19 @@
     - debug:
         var: space
 
+    - name: Creating a new directory
+      file:
+        path: "foo/"
+        state: directory
+
     # https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html
     - name: Create file
       ansible.builtin.file:
-        path:
+        path: foo/foo.txt
         state: touch
 
     # https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html
     - name: Copy file
       ansible.builtin.copy:
-        src:
-        dest:
+        src: world.txt
+        dest: foo/world.txt.bak

--- a/install_mongodb.yml
+++ b/install_mongodb.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install MongoDB
-  hosts:
+  hosts: localhost
   connection: local
   roles:
-    -
+    - mongodb


### PR DESCRIPTION
Error when installing mongo, i think need to install xcode first
`TASK [mongodb : install mongoDB (Mac OS)] ****************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error: Your Command Line Tools are too outdated.\nUpdate them from Software Update in System Preferences or run:\n  softwareupdate --all --install --force\n\nIf that doesn't show you any updates, run:\n  sudo rm -rf /Library/Developer/CommandLineTools\n  sudo xcode-select --install\n\nAlternatively, manually download them from:\n  https://developer.apple.com/download/all/.\nYou should download the Command Line Tools for Xcode 13.2.1."}`